### PR TITLE
Keyboard login fix/debugging

### DIFF
--- a/Components/Login/LoginPage.js
+++ b/Components/Login/LoginPage.js
@@ -1,7 +1,9 @@
 import { Image, Text, ZStack, VStack, Spacer, Pressable } from "native-base";
+import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 import SignUpForm from "./SignUpForm";
 import LoginForm from "./LoginForm";
 import { useState } from "react";
+
 
 export default function LoginPage() {
 	const [signIn, setSignIn] = useState(false);
@@ -9,14 +11,16 @@ export default function LoginPage() {
 	const toggleSignIn = () => {
 		setSignIn(!signIn);
 	};
+
 	return (
-		<ZStack>
+	<KeyboardAwareScrollView contentContainerStyle={{flex: 1}} >
+			<ZStack>
 			<>
 				<Image
 					source={require("../../assets/loginPage.jpg")}
 					alt="A yellow background with a hand full of fries with ketchup on then with one fry being taken by another hand"
 					style={{ width: "100%", height: "100%" }}
-				/>
+					/>
 			</>
 			<VStack w="100%" h="100%" p="5">
 				<Spacer />
@@ -72,5 +76,6 @@ export default function LoginPage() {
 				</Pressable>
 			</VStack>
 		</ZStack>
+	</KeyboardAwareScrollView>
 	);
 }

--- a/Components/Login/SignUpForm.js
+++ b/Components/Login/SignUpForm.js
@@ -69,7 +69,7 @@ export default function SignUpForm() {
 				const user = userCredential.user;
 				writeUserData(user.uid, user.email);
 				addUserData(user.uid, data.firstName, data.lastName, data.email);
-				navigation.navigate("Participants");
+				navigation.navigate("Camera");
 			})
 			.catch((error) => {
 				const errorCode = error.code;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-native": "0.70.5",
         "react-native-dotenv": "^3.4.7",
         "react-native-gesture-handler": "~2.8.0",
+        "react-native-keyboard-aware-scroll-view": "^0.9.5",
         "react-native-reanimated": "~2.12.0",
         "react-native-safe-area-context": "4.4.1",
         "react-native-screens": "~3.18.0",
@@ -18319,6 +18320,26 @@
       "version": "0.70.3",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
+    },
+    "node_modules/react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
+      }
+    },
+    "node_modules/react-native-keyboard-aware-scroll-view": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz",
+      "integrity": "sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==",
+      "dependencies": {
+        "prop-types": "^15.6.2",
+        "react-native-iphone-x-helper": "^1.0.3"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.48.4"
+      }
     },
     "node_modules/react-native-reanimated": {
       "version": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-native": "0.70.5",
     "react-native-dotenv": "^3.4.7",
     "react-native-gesture-handler": "~2.8.0",
+    "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-reanimated": "~2.12.0",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "~3.18.0",


### PR DESCRIPTION
-Successfully signing up navigates user to Camera view instead of Participants

-Installed 'react-native-keyboard-aware-view', where component 'KeyboardAwareScrollView' allows a user to scroll on login/sign up forms, in order to reach other input fields/buttons

**Tested on iOS (iPhone 11), not tested on Android